### PR TITLE
Avoid 100% CPU usage while socket is closed (sleep)

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -635,6 +635,9 @@ class KafkaClient(object):
             self._sensors.select_time.record((end_select - start_select) * 1000000000)
 
         for key, events in ready:
+            if key.fileobj.fileno() < 0:
+                time.sleep(0.1)
+
             if key.fileobj is self._wake_r:
                 self._clear_wake_fd()
                 continue

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -635,9 +635,6 @@ class KafkaClient(object):
             self._sensors.select_time.record((end_select - start_select) * 1000000000)
 
         for key, events in ready:
-            if key.fileobj.fileno() < 0:
-                self._selector.unregister(key.fileobj)
-
             if key.fileobj is self._wake_r:
                 self._clear_wake_fd()
                 continue


### PR DESCRIPTION
Unregister closed socket led to some issues, revert to `sleep` approach.