### PR TITLE
client: cleanup unresponsive sockets

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -633,10 +633,11 @@ class KafkaClient(object):
         end_select = time.time()
         if self._sensors:
             self._sensors.select_time.record((end_select - start_select) * 1000000000)
-
         for key, events in ready:
             if key.fileobj.fileno() < 0:
-                time.sleep(0.1)
+                # This will remove the connection from the list and call close on it
+                # which in turn "should" close and un-register the underlying socket
+                self.close(key.data.node_id)
 
             if key.fileobj is self._wake_r:
                 self._clear_wake_fd()

--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -86,7 +86,7 @@ class ClusterMetadata(object):
         Returns:
             set: {BrokerMetadata, ...}
         """
-        return set(self._brokers.values()) or set(self._bootstrap_brokers.values())
+        return set(self._brokers.values()).union(set(self._bootstrap_brokers.values()))
 
     def broker_metadata(self, broker_id):
         """Get BrokerMetadata

--- a/kafka/cluster.py
+++ b/kafka/cluster.py
@@ -86,7 +86,7 @@ class ClusterMetadata(object):
         Returns:
             set: {BrokerMetadata, ...}
         """
-        return set(self._brokers.values()).union(set(self._bootstrap_brokers.values()))
+        return set(self._brokers.values()) or set(self._bootstrap_brokers.values())
 
     def broker_metadata(self, broker_id):
         """Get BrokerMetadata


### PR DESCRIPTION
Properly call the close procedure on unresponsive connections, which
should handle the cleanup procedures for deregistering , transitioning
to DISCONNECTED and removing from the active connection list