### PR TITLE
client: allow for custom kafka clients

### DIFF
--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -11,7 +11,7 @@ import weakref
 from kafka.vendor import six
 
 import kafka.errors as Errors
-from kafka.client_async import KafkaClient, selectors
+from kafka.client_async import selectors
 from kafka.codec import has_gzip, has_snappy, has_lz4, has_zstd
 from kafka.metrics import MetricConfig, Metrics
 from kafka.partitioner.default import DefaultPartitioner
@@ -22,6 +22,7 @@ from kafka.record.default_records import DefaultRecordBatchBuilder
 from kafka.record.legacy_records import LegacyRecordBatchBuilder
 from kafka.serializer import Serializer
 from kafka.structs import TopicPartition
+from kafka.util import get_client_factory
 
 
 log = logging.getLogger(__name__)
@@ -281,6 +282,7 @@ class KafkaProducer(object):
         sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
             instance. (See kafka.oauth.abstract). Default: None
         socks5_proxy (str): Socks5 proxy URL. Default: None
+        client_factory (callable): Custom class / callable for creating KafkaClient instances
 
     Note:
         Configuration parameters are described in more detail at
@@ -335,6 +337,7 @@ class KafkaProducer(object):
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
         'socks5_proxy': None,
+        'client_factory': None,
     }
 
     _COMPRESSORS = {
@@ -380,9 +383,10 @@ class KafkaProducer(object):
         reporters = [reporter() for reporter in self.config['metric_reporters']]
         self._metrics = Metrics(metric_config, reporters)
 
-        client = KafkaClient(metrics=self._metrics, metric_group_prefix='producer',
-                             wakeup_timeout_ms=self.config['max_block_ms'],
-                             **self.config)
+        client = get_client_factory(self.config)(
+            metrics=self._metrics, metric_group_prefix='producer',
+            wakeup_timeout_ms=self.config['max_block_ms'],
+            **self.config)
 
         # Get auto-discovered version from client if necessary
         if self.config['api_version'] is None:

--- a/kafka/util.py
+++ b/kafka/util.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import
 
 import binascii
 import weakref
+import kafka
+import logging
 
 from kafka.vendor import six
-
 
 if six.PY3:
     MAX_INT = 2 ** 31
@@ -20,6 +21,7 @@ if six.PY3:
         return crc
 else:
     from binascii import crc32
+log = logging.getLogger(__name__)
 
 
 class WeakMethod(object):
@@ -64,3 +66,14 @@ class Dict(dict):
     See: https://docs.python.org/2/library/weakref.html
     """
     pass
+
+
+def get_client_factory(config):
+    if config.get('client_factory') is not None:
+        client_factory = config['client_factory']
+        assert callable(client_factory), "'client_factory' should be a callable or None, is {}".format(type(client_factory))
+        log.info("Initializing custom kafka client")
+    else:
+        client_factory = kafka.client_async.KafkaClient
+        log.info("Initializing normal kafka client")
+    return client_factory


### PR DESCRIPTION
Provide the consumer, producer and admin client with the option to
create the kafka client from a custom callable, thus allowing more
flexibility in handling certain low level errors