### PR TITLE
conn: disconnection triggers a state change cb

### DIFF
--- a/kafka/conn.py
+++ b/kafka/conn.py
@@ -367,6 +367,7 @@ class BrokerConnection(object):
             next_lookup = self._next_afi_sockaddr()
             if not next_lookup:
                 self.close(Errors.KafkaConnectionError('DNS failure'))
+                self.config['state_change_callback'](self.node_id, self._sock, self)
                 return self.state
             else:
                 log.debug('%s: creating new socket', self)


### PR DESCRIPTION
More in line with the Java client, transitioning from DISCONNECTED to
DISCONNECTED via DNS failure should also call the state changed
callback, that will ensurethat the connection will no longer be polled
and also force an early metadata update