### PR TITLE
Add support for SASL v1

### DIFF
--- a/kafka/admin/client.py
+++ b/kafka/admin/client.py
@@ -177,6 +177,7 @@ class KafkaAdminClient(object):
         'api_version_auto_timeout_ms': 2000,
         'selector': selectors.DefaultSelector,
         'sasl_mechanism': None,
+        'sasl_version':  0,
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -187,6 +187,7 @@ class KafkaClient(object):
         'selector': selectors.DefaultSelector,
         'metrics': None,
         'metric_group_prefix': '',
+        'sasl_version':  0,
         'sasl_mechanism': None,
         'sasl_plain_username': None,
         'sasl_plain_password': None,

--- a/kafka/consumer/group.py
+++ b/kafka/consumer/group.py
@@ -301,6 +301,7 @@ class KafkaConsumer(six.Iterator):
         'selector': selectors.DefaultSelector,
         'exclude_internal_topics': True,
         'sasl_mechanism': None,
+        'sasl_version':  0,
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -329,6 +329,7 @@ class KafkaProducer(object):
         'metrics_sample_window_ms': 30000,
         'selector': selectors.DefaultSelector,
         'sasl_mechanism': None,
+        'sasl_version':  0,
         'sasl_plain_username': None,
         'sasl_plain_password': None,
         'sasl_kerberos_service_name': 'kafka',


### PR DESCRIPTION
This draft PR enables kafka-python to authenticate against Kafka clusters running SCRAM authentication with `SASL_VERSION  1`.
The code is ugly and hackish at best, but it works, it's currently running it in production.

we were unable to get familiar with the self-made future library and in turn provide proper error handling, causing failed authentication (bad username / password, host etc.) to be stuck in the expected re-authentication loop without returning any specific error.

I'd love to follow this PR to the door, but I would need some assistance from someone familiar with this project on how to rework the futures and general error handling for `SASL_VERSION  1`.