### PR TITLE
bugfix: raise error in check_version if broker is unavailable

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -911,7 +911,8 @@ class KafkaClient(object):
             if try_node is None:
                 self._lock.release()
                 raise Errors.NoBrokersAvailable()
-            self._maybe_connect(try_node)
+            if not self._maybe_connect(try_node):
+                raise Errors.BrokerNotAvailableError()
             conn = self._conns[try_node]
 
             # We will intentionally cause socket failures


### PR DESCRIPTION
This fixes an issue in check_version where KeyError is raised if the broker is unavailable or an invalid node_id is used. Instead it will return BrokerNotAvailableError.
