### PR TITLE
Revert "bugfix: raise error in check_version if broker is unavailable"

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -911,8 +911,7 @@ class KafkaClient(object):
             if try_node is None:
                 self._lock.release()
                 raise Errors.NoBrokersAvailable()
-            if not self._maybe_connect(try_node):
-                raise Errors.BrokerNotAvailableError()
+            self._maybe_connect(try_node)
             conn = self._conns[try_node]
 
             # We will intentionally cause socket failures


### PR DESCRIPTION
Reverts aiven/kafka-python#25

Reverting PR because it introduced some issues by circumventing the timeout of check_version method.