### PR TITLE
bugfix: catch KeyError in check_version and retry

### DIFF
--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -912,7 +912,13 @@ class KafkaClient(object):
                 self._lock.release()
                 raise Errors.NoBrokersAvailable()
             self._maybe_connect(try_node)
-            conn = self._conns[try_node]
+            try:
+                conn = self._conns[try_node]
+            except KeyError:
+                if node_id is not None:
+                    self._lock.release()
+                    raise Errors.NodeNotReadyError()
+                continue
 
             # We will intentionally cause socket failures
             # These should not trigger metadata refresh


### PR DESCRIPTION
This fixes an issue in check_version where KeyError is raised if the broker is unavailable or an invalid node_id is used. Instead it will return NodeNotReadyError if node_id is specified and otherwise retry.
